### PR TITLE
Backport changes from 606feb6a61bb67417ad479eae8e8eb871867a2d0 to 1.16.x forge version

### DIFF
--- a/forge/src/main/java/top/theillusivec4/elytrautilities/Constants.java
+++ b/forge/src/main/java/top/theillusivec4/elytrautilities/Constants.java
@@ -36,5 +36,9 @@ public class Constants {
         "Set to true to enable an icon that appears on the HUD when elytra flight is disabled";
     public static final String SIMPLE_TAKEOFF_DESC =
         "Set to true to enable holding down the Trigger Elytra keybind to automatically use a firework from inventory to takeoff from ground level";
+    public static final String ENABLE_ELYTRA_DESC =
+            "Set to true to enable elytra flight as normal, false to disable elytra flight. This can also be managed in-game through the \"Toggle Elytra\" keybinding.";
+    public static final String ENABLE_JUMP_TRIGGER =
+            "Set to true to enable jump triggering the elytra while falling as normal, false to disable.";
   }
 }

--- a/forge/src/main/java/top/theillusivec4/elytrautilities/ElytraUtilitiesMod.java
+++ b/forge/src/main/java/top/theillusivec4/elytrautilities/ElytraUtilitiesMod.java
@@ -21,8 +21,6 @@
 
 package top.theillusivec4.elytrautilities;
 
-import net.minecraft.client.entity.player.ClientPlayerEntity;
-import net.minecraft.inventory.EquipmentSlotType;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.fml.ExtensionPoint;
 import net.minecraftforge.fml.ModList;
@@ -30,9 +28,11 @@ import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
+import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.fml.network.FMLNetworkConstants;
 import org.apache.commons.lang3.tuple.Pair;
+import top.theillusivec4.elytrautilities.common.network.NetworkHandler;
 import top.theillusivec4.elytrautilities.client.ClientEventsListener;
 import top.theillusivec4.elytrautilities.client.KeyRegistry;
 import top.theillusivec4.elytrautilities.common.CaelusPlugin;
@@ -41,23 +41,18 @@ import top.theillusivec4.elytrautilities.common.ConfigReader;
 @Mod(Constants.MOD_ID)
 public class ElytraUtilitiesMod {
 
-  private static boolean isCaelusLoaded = false;
-
   public ElytraUtilitiesMod() {
     IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
+    modEventBus.addListener(this::setup);
     modEventBus.addListener(this::clientSetup);
     ModLoadingContext.get().registerConfig(ModConfig.Type.CLIENT, ConfigReader.CLIENT_SPEC);
     ModLoadingContext.get().registerExtensionPoint(ExtensionPoint.DISPLAYTEST,
         () -> Pair.of(() -> FMLNetworkConstants.IGNORESERVERONLY, (a, b) -> true));
-    isCaelusLoaded = ModList.get().isLoaded("caelus");
+    CaelusPlugin.isCaelusLoaded = ModList.get().isLoaded("caelus");
   }
 
-  public static boolean canFly(ClientPlayerEntity player) {
-
-    if (isCaelusLoaded) {
-      return CaelusPlugin.canFly(player);
-    }
-    return player.getItemBySlot(EquipmentSlotType.CHEST).canElytraFly(player);
+  private void setup(FMLCommonSetupEvent evt) {
+    NetworkHandler.register();
   }
 
   private void clientSetup(final FMLClientSetupEvent evt) {

--- a/forge/src/main/java/top/theillusivec4/elytrautilities/client/ClientEvents.java
+++ b/forge/src/main/java/top/theillusivec4/elytrautilities/client/ClientEvents.java
@@ -35,7 +35,7 @@ import net.minecraft.util.MovementInput;
 import net.minecraft.util.ResourceLocation;
 import top.theillusivec4.elytrautilities.Constants;
 import top.theillusivec4.elytrautilities.ElytraUtilitiesMod;
-import top.theillusivec4.elytrautilities.common.ConfigReader;
+import top.theillusivec4.elytrautilities.common.ClientConfig;
 
 public class ClientEvents {
 
@@ -102,7 +102,7 @@ public class ClientEvents {
         cooldown--;
       }
 
-      if (ConfigReader.CLIENT.simpleTakeoff.get() && triggerFlightUse > 0) {
+      if (ClientConfig.canSimpleTakeoff() && triggerFlightUse > 0) {
 
         if (isTriggerKeyDown) {
           triggerFlightUse++;
@@ -131,7 +131,7 @@ public class ClientEvents {
 
   public static void renderIcon(MatrixStack poseStack) {
 
-    if (ConfigReader.CLIENT.toggleIcon.get() && ClientFlightController.isFlightDisabled()) {
+    if (ClientConfig.canRenderIcon() && ClientFlightController.isFlightDisabled()) {
       Minecraft.getInstance().getTextureManager().bind(DISABLED_ICON);
       AbstractGui.blit(poseStack, 2, 2, 0, 0, 24, 24, 24, 24);
     }

--- a/forge/src/main/java/top/theillusivec4/elytrautilities/client/ClientEvents.java
+++ b/forge/src/main/java/top/theillusivec4/elytrautilities/client/ClientEvents.java
@@ -27,14 +27,16 @@ import net.minecraft.client.entity.player.ClientPlayerEntity;
 import net.minecraft.client.gui.AbstractGui;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.Items;
-import net.minecraft.network.play.client.CEntityActionPacket;
 import net.minecraft.network.play.client.CPlayerTryUseItemPacket;
 import net.minecraft.potion.Effects;
 import net.minecraft.util.Hand;
 import net.minecraft.util.MovementInput;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.network.PacketDistributor;
+import top.theillusivec4.elytrautilities.common.network.CPacketSetFlight;
+import top.theillusivec4.elytrautilities.common.network.NetworkHandler;
 import top.theillusivec4.elytrautilities.Constants;
-import top.theillusivec4.elytrautilities.ElytraUtilitiesMod;
+import top.theillusivec4.elytrautilities.common.CaelusPlugin;
 import top.theillusivec4.elytrautilities.common.ClientConfig;
 
 public class ClientEvents {
@@ -49,8 +51,7 @@ public class ClientEvents {
   private static int triggerFlightUse = 0;
 
   private static void startFlight(ClientPlayerEntity player) {
-    player.connection.send(
-        new CEntityActionPacket(player, CEntityActionPacket.Action.START_FALL_FLYING));
+    NetworkHandler.INSTANCE.send(PacketDistributor.SERVER.noArg(), new CPacketSetFlight());
     triggerJump = false;
     triggerFlight = false;
     triggerFlightUse++;
@@ -80,7 +81,7 @@ public class ClientEvents {
       final boolean canFly = !ClientFlightController.isFlightDisabled() &&
           !player.abilities.flying && !player.isPassenger() && !player.onClimbable() &&
           !player.isFallFlying() && !player.isInWater() &&
-          !player.hasEffect(Effects.LEVITATION) && ElytraUtilitiesMod.canFly(player);
+          !player.hasEffect(Effects.LEVITATION) && CaelusPlugin.canFly(player);
 
       if (canFly) {
 

--- a/forge/src/main/java/top/theillusivec4/elytrautilities/client/ClientFlightController.java
+++ b/forge/src/main/java/top/theillusivec4/elytrautilities/client/ClientFlightController.java
@@ -25,20 +25,20 @@ import net.minecraft.client.entity.player.ClientPlayerEntity;
 import net.minecraft.util.text.TranslationTextComponent;
 import top.theillusivec4.elytrautilities.Constants;
 import top.theillusivec4.elytrautilities.ElytraUtilitiesMod;
+import top.theillusivec4.elytrautilities.common.ClientConfig;
 
 public class ClientFlightController {
 
-  private static boolean flightEnabled = true;
-
   public static boolean isFlightDisabled() {
-    return !flightEnabled;
+    return !ClientConfig.isElytraEnabled();
   }
 
   public static void toggleFlight(ClientPlayerEntity player) {
     TranslationTextComponent text;
-    flightEnabled = !flightEnabled;
+    boolean state = !ClientConfig.isElytraEnabled();
+    ClientConfig.setElytraEnabled(state);
 
-    if (flightEnabled) {
+    if (state) {
       text = new TranslationTextComponent(Constants.MOD_ID + ".enableFlight");
     } else {
       text = new TranslationTextComponent(Constants.MOD_ID + ".disableFlight");

--- a/forge/src/main/java/top/theillusivec4/elytrautilities/common/CaelusPlugin.java
+++ b/forge/src/main/java/top/theillusivec4/elytrautilities/common/CaelusPlugin.java
@@ -22,11 +22,17 @@
 package top.theillusivec4.elytrautilities.common;
 
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.inventory.EquipmentSlotType;
 import top.theillusivec4.caelus.api.CaelusApi;
 
 public class CaelusPlugin {
 
+  public static boolean isCaelusLoaded = false;
+
   public static boolean canFly(final LivingEntity livingEntity) {
-    return CaelusApi.canElytraFly(livingEntity);
+    if (isCaelusLoaded) {
+      return CaelusApi.canElytraFly(livingEntity);
+    }
+    return livingEntity.getItemBySlot(EquipmentSlotType.CHEST).canElytraFly(livingEntity);
   }
 }

--- a/forge/src/main/java/top/theillusivec4/elytrautilities/common/ClientConfig.java
+++ b/forge/src/main/java/top/theillusivec4/elytrautilities/common/ClientConfig.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2022 C4
+ *
+ * This file is part of Elytra Utilities.
+ *
+ * Elytra Utilities is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Elytra Utilities is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * and the GNU Lesser General Public License along with Elytra Utilities.
+ * If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package top.theillusivec4.elytrautilities.common;
+
+import top.theillusivec4.elytrautilities.common.ConfigReader;
+
+public class ClientConfig {
+
+    public static boolean canSimpleTakeoff() {
+        return ConfigReader.CLIENT.simpleTakeoff.get();
+    }
+
+    public static boolean canRenderIcon() {
+        return ConfigReader.CLIENT.toggleIcon.get();
+    }
+
+    public static boolean isJumpTriggerable() {
+        return ConfigReader.CLIENT.jumpTriggerable.get();
+    }
+
+    public static boolean isElytraEnabled() {
+        return ConfigReader.CLIENT.enableElytra.get();
+    }
+
+    public static void setElytraEnabled(boolean state) {
+        ConfigReader.CLIENT.enableElytra.set(state);
+        ConfigReader.CLIENT.enableElytra.save();
+    }
+}

--- a/forge/src/main/java/top/theillusivec4/elytrautilities/common/ConfigReader.java
+++ b/forge/src/main/java/top/theillusivec4/elytrautilities/common/ConfigReader.java
@@ -42,6 +42,8 @@ public class ConfigReader {
 
     public final ForgeConfigSpec.BooleanValue toggleIcon;
     public final ForgeConfigSpec.BooleanValue simpleTakeoff;
+    public final ForgeConfigSpec.BooleanValue enableElytra;
+    public final ForgeConfigSpec.BooleanValue jumpTriggerable;
 
     Client(ForgeConfigSpec.Builder builder) {
 
@@ -51,6 +53,10 @@ public class ConfigReader {
           .translation(CONFIG_PREFIX + "toggleIcon").define("toggleIcon", true);
       simpleTakeoff = builder.comment(Constants.Config.SIMPLE_TAKEOFF_DESC)
           .translation(CONFIG_PREFIX + "simpleTakeoff").define("simpleTakeoff", true);
+      enableElytra = builder.comment(Constants.Config.ENABLE_ELYTRA_DESC)
+              .translation(CONFIG_PREFIX + "enableElytra").define("enableElytra", true);
+      jumpTriggerable = builder.comment(Constants.Config.ENABLE_JUMP_TRIGGER)
+              .translation(CONFIG_PREFIX + "jumpTriggerable").define("jumpTriggerable", true);
 
       builder.pop();
     }

--- a/forge/src/main/java/top/theillusivec4/elytrautilities/common/network/CPacketSetFlight.java
+++ b/forge/src/main/java/top/theillusivec4/elytrautilities/common/network/CPacketSetFlight.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2019  C4
+ *
+ * This file is part of Caelus, a mod made for Minecraft.
+ *
+ * Caelus is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Caelus is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with Caelus.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package top.theillusivec4.elytrautilities.common.network;
+
+import net.minecraft.entity.player.ServerPlayerEntity;
+import net.minecraft.network.PacketBuffer;
+import net.minecraft.potion.Effects;
+import net.minecraftforge.fml.network.NetworkEvent;
+import top.theillusivec4.elytrautilities.common.CaelusPlugin;
+
+import java.util.function.Supplier;
+
+public class CPacketSetFlight {
+
+  public static void encode(CPacketSetFlight msg, PacketBuffer buf) {
+  }
+
+  public static CPacketSetFlight decode(PacketBuffer buf) {
+    return new CPacketSetFlight();
+  }
+
+  public static void handle(CPacketSetFlight msg, Supplier<NetworkEvent.Context> ctx) {
+
+    ctx.get().enqueueWork(() -> {
+      ServerPlayerEntity sender = ctx.get().getSender();
+
+      if (sender == null) {
+        return;
+      }
+      sender.stopFallFlying();
+
+      if (!sender.isOnGround() && !sender.isFallFlying() && !sender.isInWater() && !sender
+          .hasEffect(Effects.LEVITATION) && CaelusPlugin.canFly(sender)) {
+        sender.startFallFlying();
+      } else {
+        sender.stopFallFlying();
+      }
+    });
+    ctx.get().setPacketHandled(true);
+  }
+}

--- a/forge/src/main/java/top/theillusivec4/elytrautilities/common/network/NetworkHandler.java
+++ b/forge/src/main/java/top/theillusivec4/elytrautilities/common/network/NetworkHandler.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2019  C4
+ *
+ * This file is part of Caelus, a mod made for Minecraft.
+ *
+ * Caelus is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Caelus is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with Caelus.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package top.theillusivec4.elytrautilities.common.network;
+
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.network.NetworkRegistry;
+import net.minecraftforge.fml.network.simple.SimpleChannel;
+import top.theillusivec4.elytrautilities.Constants;
+
+public class NetworkHandler {
+
+  private static final String PTC_VERSION = "1";
+
+  public static SimpleChannel INSTANCE;
+
+  private static int id = 0;
+
+  public static void register() {
+    INSTANCE = NetworkRegistry.ChannelBuilder.named(new ResourceLocation(Constants.MOD_ID, "main"))
+        .networkProtocolVersion(() -> PTC_VERSION).clientAcceptedVersions(PTC_VERSION::equals)
+        .serverAcceptedVersions(PTC_VERSION::equals).simpleChannel();
+
+    INSTANCE.registerMessage(id++, CPacketSetFlight.class, CPacketSetFlight::encode,
+        CPacketSetFlight::decode, CPacketSetFlight::handle);
+  }
+}

--- a/forge/src/main/java/top/theillusivec4/elytrautilities/mixin/ClientPlayerMixin.java
+++ b/forge/src/main/java/top/theillusivec4/elytrautilities/mixin/ClientPlayerMixin.java
@@ -27,6 +27,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import top.theillusivec4.elytrautilities.client.ClientFlightController;
+import top.theillusivec4.elytrautilities.common.ClientConfig;
 
 @Mixin(value = ClientPlayerEntity.class, priority = 900)
 public class ClientPlayerMixin {
@@ -41,7 +42,7 @@ public class ClientPlayerMixin {
       ordinal = 5)
   private boolean elytrautilities$aiStep(boolean flag7) {
 
-    if (ClientFlightController.isFlightDisabled()) {
+    if (ClientFlightController.isFlightDisabled() || !ClientConfig.isJumpTriggerable()) {
       return true;
     } else {
       return flag7;


### PR DESCRIPTION
This adds changes made in the 1.18.x and 1.19.x branches to the 1.16.x Forge version.

While running Tinkers Construct 3 and your mod [Elytra Slot (Forge)](https://www.curseforge.com/minecraft/mc-mods/elytra-slot) on version 1.16.5, I found that the double jump ability from TiC3 caused me to enter flight mode while wearing Elytra. Before doing something reckless like creating my own mod to remedy this, I searched for one that would add a separate Elytra activation key and disable jump activation. I found this mod, but the changes I needed were only in the 1.18.x and 1.19.x versions, so I've backported them to 1.16.x for my own usage.

I'm not familiar with Fabric and I'm not currently using it, so I've not made any changes there. In any case, I figured making a pull request for the Forge version only wouldn't hurt.